### PR TITLE
Update ObjectInstanceIdGenerator.java

### DIFF
--- a/core/mo-services-impl/ccsds-com-impl/src/main/java/esa/mo/com/impl/util/ObjectInstanceIdGenerator.java
+++ b/core/mo-services-impl/ccsds-com-impl/src/main/java/esa/mo/com/impl/util/ObjectInstanceIdGenerator.java
@@ -47,7 +47,7 @@ public class ObjectInstanceIdGenerator
    */
   public static ObjectInstanceIdGenerator getInstance()
   {
-    if (instance == null) {
+    if (instance == null) 
       instance = new ObjectInstanceIdGenerator();
     }
     return instance;


### PR DESCRIPTION
Singleton is not thread safe
Non-thread safe singletons can result in bad state changes. Eliminate static singletons if possible by instantiating the object directly. Static singletons are usually not needed as only a single instance exists anyway. Other possible fixes are to synchronize the entire method or to use an initialize-on-demand holder class (do not use the double-check idiom).