### PR TITLE
Update OrekitCore.java

### DIFF
--- a/mission/simulator/opssat-spacecraft-simulator/src/main/java/opssat/simulator/orekit/OrekitCore.java
+++ b/mission/simulator/opssat-spacecraft-simulator/src/main/java/opssat/simulator/orekit/OrekitCore.java
@@ -1056,7 +1056,7 @@ public class OrekitCore
         }
       }
     }
-    if (debug1) {
+    if (debug1)() {
       logger.log(Level.INFO, "Failed to find " + nodeDetectStr + " after [" + i + "] steps!");
     }
     return null;


### PR DESCRIPTION
Logger calls should be surrounded by log level guards.
Whenever using a log level, one should check if the loglevel is actually enabled, or otherwise skip the associate String creation and manipulation.